### PR TITLE
Switch to python:3.8 for more functional base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-alpine
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: "sceptre-gitHub-action"
+name: "sceptre-github-action"
 description: "Runs sceptre commands via GitHub Actions"
 branding:
   icon: 'activity'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 ---
-name: "Sceptre GitHub Action"
+name: "sceptre-gitHub-action"
 description: "Runs sceptre commands via GitHub Actions"
 branding:
   icon: 'activity'


### PR DESCRIPTION
We use sceptre hooks to run commands like `wget` or `curl`. Unfortunately, the `python:3.8-slim` base image doesn't come with a lot of these basic commands. This PR addresses this by changing the base image to `python:3.8`, which is a more fully functional image. 